### PR TITLE
Use the correct API to avoid NumberFormatException crashing the app

### DIFF
--- a/app/src/main/java/com/martin/form/MainActivity.java
+++ b/app/src/main/java/com/martin/form/MainActivity.java
@@ -51,10 +51,11 @@ public class MainActivity extends AppCompatActivity {
         if (intent.hasExtra("YYYY") &&
                 intent.hasExtra("MM") &&
                 intent.hasExtra("DD")) {
-            int year = Integer.parseInt(intent.getStringExtra("YYYY"));
-            int month = Integer.parseInt(intent.getStringExtra("MM")) - 1;
-            int day = Integer.parseInt(intent.getStringExtra("DD"));
-            datePicker.init(year,month,day,null);
+                int year = intent.getIntExtra("YYYY", 0);
+                int month = intent.getIntExtra("MM", 0) - 1;
+                int day = intent.getIntExtra("DD", 0);
+
+                datePicker.init(year,month,day,null);
         } else {
             final Calendar c = Calendar.getInstance();
             int year = c.get(Calendar.YEAR);


### PR DESCRIPTION
Hi Martin,

Thanks for sharing the project <code>taitocode/form-android</code> and it's a nice one.

I noticed one issue - in the program <code>app/src/main/java/com/martin/form/MainActivity.java</code>, it has the following code:
```
            int year = Integer.parseInt(intent.getStringExtra("YYYY"));
            int month = Integer.parseInt(intent.getStringExtra("MM")) - 1;
            int day = Integer.parseInt(intent.getStringExtra("DD"));
```

If an invalid number is passed to the intent, the code will throw a <code>NumberFormatException</code> that will crash the app. For example:
```
            Intent intent = new Intent();
            intent.setClassName("com.martin.form", "com.martin.form.MainActivity");
            intent.setAction("android.intent.action.VIEW");

            intent.putExtra("YYYY", "a");
            intent.putExtra("MM", "b");
            intent.putExtra("DD", "c");

            startActivity(intent);
```

A screenshot is as follows:
<img src="https://user-images.githubusercontent.com/37377780/98442911-f6764100-20d5-11eb-8c01-4a7a0a195801.png" width="50%" height="50%" />

To fix this issue, the correct way is to use the proper Android API for getting int extras, which has the built-in try/catch block to handle <code>NumberFormatException</code>, which is:
```
                int year = intent.getIntExtra("YYYY", 0);
                int month = intent.getIntExtra("MM", 0) - 1;
                int day = intent.getIntExtra("DD", 0);
```

I've made the fix in my Pull Request (PR), please consider to merge the request.

Thanks,
@luchua-bc
